### PR TITLE
 Changed the execute of ffmpeg from exec to spwan.

### DIFF
--- a/export.js
+++ b/export.js
@@ -155,6 +155,11 @@ function convertAndCopy(filename){
 
     ls.on('close', (code) => {
         console.log(`child process exited with code ${code}`);
+        if(code == 0)
+        {
+            fs.unlinkSync(copyFrom);
+        }
+       
     });
 
 

--- a/export.js
+++ b/export.js
@@ -127,8 +127,38 @@ function convertAndCopy(filename){
     var cmd = "ffmpeg -y -i '" + copyFrom + "' -c:v libx264 -preset veryfast -movflags faststart -profile:v high -level 4.2 -max_muxing_queue_size 9999 -vf mpdecimate -vsync vfr '" + copyTo + "'";
 
     console.log("converting using: " + cmd);
-    
-    exec(cmd, function(err, stdout, stderr) {
+    const { spawn } = require('child_process');
+    const ls = spawn('ffmpeg',
+        ['-y',
+            '-i ' + copyFrom,
+            '-c:v libx264',
+            '-preset veryfast',
+            '-movflags faststart',
+            '-profile:v high',
+            '-level 4.2',
+            '-max_muxing_queue_size 9999',
+            '-vf mpdecimate',
+            '-vsync vfr ' + copyTo],
+        {
+            shell: true
+        }
+
+    );
+
+    ls.stdout.on('data', (data) => {
+        console.log(`stdout: ${data}`);
+    });
+
+    ls.stderr.on('data', (data) => {
+        console.error(`stderr: ${data}`);
+    });
+
+    ls.on('close', (code) => {
+        console.log(`child process exited with code ${code}`);
+    });
+
+
+    /* exec(cmd, function(err, stdout, stderr) {
 
         if (err) console.log('err:\n' + err);
         //if (stderr) console.log('stderr:\n' + stderr);
@@ -142,7 +172,7 @@ function convertAndCopy(filename){
               console.log(err)
             }
         }
-    });
+     }); */
 }
 
 function copyOnly(filename){


### PR DESCRIPTION
With convertion of very long videos, ffmpeg generates too much output on stdout which overflows the small buffer of exec.
It is bad practice to just use a bigger buffer, instead use spwan which returns a stream. Therefor no buffer overflow is possible any longer