### PR TITLE
Warning that download folder is assumed to be ~/Downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 Bigbluebutton recordings export to `webm` or `mp4` & live broadcasting. This is an example how I have implemented BBB recordings to distibutable file. 
 
+1. We assume your download folder is `~/Downloads`. If it's not, please edit `export.js`.
 1. Videos will be copy to `/var/www/bigbluebutton-default/record`. You can change value of `copyToPath` from `config.json`.
-3. Can be converted to `mp4`. Default `webm`
-2. Specify bitrate to control quality of the exported video by adjusting `videoBitsPerSecond` property in `background.js`
+1. Can be converted to `mp4`. Default `webm`
+1. Specify bitrate to control quality of the exported video by adjusting `videoBitsPerSecond` property in `background.js`
 
 
 ### Dependencies


### PR DESCRIPTION
Hi, thanks a lot for this!

First I didn't understand why it said it couldn't locate `~/Downloads/meeting.webm` even if I created the folder.
Then I understood that in my language, the `Downloads` folder is `Téléchargements`.

Maybe you want to put the path to Downloads in `config.json`?

Also: my video was converted to mp4 even if the flag was `false`. Just so you know :)