### PR TITLE
Prevent memory leak

### DIFF
--- a/export.js
+++ b/export.js
@@ -153,7 +153,6 @@ async function main() {
         console.log(err)
     } finally {
         page.close && await page.close()
-
         browser.close && await browser.close()
     }
 }

--- a/export.js
+++ b/export.js
@@ -38,6 +38,8 @@ if(platform == "linux"){
 }
 
 async function main() {
+    let browser, page;
+
     try{
         if(platform == "linux"){
             xvfb.startSync()
@@ -79,8 +81,8 @@ async function main() {
             process.exit(1);
         }
 
-        const browser = await puppeteer.launch(options)
-        const pages = await browser.pages()
+        browser = await puppeteer.launch(options)
+        pages = await browser.pages()
 
         const page = pages[0]
 
@@ -136,8 +138,6 @@ async function main() {
 
         // Wait for download of webm to complete
         await page.waitForSelector('html.downloadComplete', {timeout: 0})
-        await page.close()
-        await browser.close()
 
         if(platform == "linux"){
             xvfb.stopSync()
@@ -151,6 +151,10 @@ async function main() {
 
     }catch(err) {
         console.log(err)
+    } finally {
+        page.close && await page.close()
+
+        browser.close && await browser.close()
     }
 }
 

--- a/export.js
+++ b/export.js
@@ -139,10 +139,6 @@ async function main() {
         // Wait for download of webm to complete
         await page.waitForSelector('html.downloadComplete', {timeout: 0})
 
-        if(platform == "linux"){
-            xvfb.stopSync()
-        }
-
         if(convert){
             convertAndCopy(exportname)
         }else{
@@ -154,6 +150,10 @@ async function main() {
     } finally {
         page.close && await page.close()
         browser.close && await browser.close()
+
+        if(platform == "linux"){
+            xvfb.stopSync()
+        }
     }
 }
 

--- a/liveJoin.js
+++ b/liveJoin.js
@@ -38,6 +38,8 @@ if(platform == "linux"){
 }
 
 async function main() {
+    let browser, page;
+
     try{
         if(platform == "linux"){
             xvfb.startSync()
@@ -52,8 +54,8 @@ async function main() {
         //if(!duration){ duration = 10 }
         if(!convert){ convert = false }
 
-        const browser = await puppeteer.launch(options)
-        const pages = await browser.pages()
+        browser = await puppeteer.launch(options)
+        pages = await browser.pages()
 
         const page = pages[0]
 
@@ -115,6 +117,10 @@ async function main() {
 
     }catch(err) {
         console.log(err)
+    } finally {
+        page.close && await page.close()
+
+        browser.close && await browser.close()
     }
 }
 

--- a/liveJoin.js
+++ b/liveJoin.js
@@ -105,10 +105,6 @@ async function main() {
         await page.close()
         await browser.close()
 
-        if(platform == "linux"){
-            xvfb.stopSync()
-        }
-
         if(convert){
             convertAndCopy(exportname)
         }else{
@@ -120,6 +116,10 @@ async function main() {
     } finally {
         page.close && await page.close()
         browser.close && await browser.close()
+
+        if(platform == "linux"){
+            xvfb.stopSync()
+        }
     }
 }
 

--- a/liveJoin.js
+++ b/liveJoin.js
@@ -119,7 +119,6 @@ async function main() {
         console.log(err)
     } finally {
         page.close && await page.close()
-
         browser.close && await browser.close()
     }
 }

--- a/liveRTMP.js
+++ b/liveRTMP.js
@@ -39,6 +39,8 @@ if(platform == "linux"){
 }
 
 async function main() {
+    let browser, page;
+
     try{
         if(platform == "linux"){
             xvfb.startSync()
@@ -50,8 +52,8 @@ async function main() {
         if(!url){ url = 'https://www.mynaparrot.com/' }
         //if(!duration){ duration = 10 }
 
-        const browser = await puppeteer.launch(options)
-        const pages = await browser.pages()
+        browser = await puppeteer.launch(options)
+        pages = await browser.pages()
 
         const page = pages[0]
 
@@ -103,8 +105,6 @@ async function main() {
 
         // Wait for download of webm to complete
         await page.waitForSelector('html.downloadComplete', {timeout: 0})
-        await page.close()
-        await browser.close()
 
         if(platform == "linux"){
             xvfb.stopSync()
@@ -114,6 +114,10 @@ async function main() {
 
     }catch(err) {
         console.log(err)
+    } finally {
+        page.close && await page.close()
+
+        browser.close && await browser.close()
     }
 }
 

--- a/liveRTMP.js
+++ b/liveRTMP.js
@@ -116,7 +116,6 @@ async function main() {
         console.log(err)
     } finally {
         page.close && await page.close()
-
         browser.close && await browser.close()
     }
 }

--- a/liveRTMP.js
+++ b/liveRTMP.js
@@ -106,10 +106,6 @@ async function main() {
         // Wait for download of webm to complete
         await page.waitForSelector('html.downloadComplete', {timeout: 0})
 
-        if(platform == "linux"){
-            xvfb.stopSync()
-        }
-
         fs.unlinkSync(homedir + "/Downloads/liveMeeting.webm");
 
     }catch(err) {
@@ -117,6 +113,10 @@ async function main() {
     } finally {
         page.close && await page.close()
         browser.close && await browser.close()
+
+        if(platform == "linux"){
+            xvfb.stopSync()
+        }
     }
 }
 


### PR DESCRIPTION
This PR resolves a memory leak.

While a browser instance is open, chances are an exception throws. If we close the `browser` instance in `try` block, then we'll miss the chance to close it gracefully and it'll stay open forever. `finally` is a good place to close instances whether the job was successful or not. For this purpose, we can keep a reference out of the `try` block and use it in the `finally `block. (I used ES6 `let` keyword which creates block-scoped variables)

This is a good article about the topic, It's in Java:
[Java: How to use the finally keyword to avoid resource leaks](http://mrbool.com/java-how-to-use-the-finally-keyword-to-avoid-resource-leaks/28903)