### PR TITLE
Add support for BBB v2.3 to export.js

### DIFF
--- a/export.js
+++ b/export.js
@@ -112,14 +112,14 @@ async function main() {
         // Check if recording exists
         if (bbbVersionIs23) {
             pageMessage = await page.evaluate(() => {
-                if (document.getElementById("load-msg")) {
-                    return document.getElementById("load-msg").textContent;
+                if (document.getElementsByClassName("error-code")[0]) {
+                    return document.getElementsByClassName("error-code")[0].textContent;
                 }
             });
         } else  {
             pageMessage = await page.evaluate(() => {
-                if (document.getElementsByClassName("error-code")[0]) {
-                    return document.getElementsByClassName("error-code")[0].textContent;
+                if (document.getElementById("load-msg")) {
+                    return document.getElementById("load-msg").textContent;
                 }
             });
         }

--- a/export.js
+++ b/export.js
@@ -68,7 +68,7 @@ async function main() {
         var exportname = process.argv[3];
         // Use meeting ID as export name if it isn't defined or if its value is "MEETING_ID"
         if (!exportname || exportname == "MEETING_ID") {
-            exportname = bbbVersionIs22 ? url.split("=")[1] + '.webm' : url.split('2.3/')[1] + '.webm';
+            exportname = bbbVersionIs23 ? url.split('2.3/')[1] + '.webm' : url.split("=")[1] + '.webm';
         }
 
         var duration = process.argv[4];
@@ -123,9 +123,10 @@ async function main() {
         // Get recording duration
         var recDuration = await page.evaluate(() => {
             return (
-                bbbVersionIs22 ?
-                document.getElementById("video").duration :
-                document.getElementById("vjs_video_3_html5_api").duration
+                bbbVersionIs23 ?
+                document.getElementById("vjs_video_3_html5_api").duration :
+                document.getElementById("video").duration
+
             );
         });
         // If duration was set to 0 or is greater than recDuration, use recDuration value
@@ -133,13 +134,13 @@ async function main() {
             duration = recDuration;
         }
 
-        if (bbbVersionIs22) {
+        if (!bbbVersionIs23) {
             await page.waitForSelector('button[class=acorn-play-button]');
             await page.$eval('#navbar', element => element.style.display = "none");
             await page.$eval('#copyright', element => element.style.display = "none");
             await page.$eval('.acorn-controls', element => element.style.opacity = "0");
             await page.click('button[class=acorn-play-button]', { waitUntil: 'domcontentloaded' });
-        } else if (bbbVersionIs23) {
+        } else {
             await page.waitForSelector('button[class~="vjs-play-control"]');
             await page.$eval('.top-bar', element => element.style.display = "none");
             await page.$eval('.bottom-content', element => element.style.display = "none");

--- a/export.js
+++ b/export.js
@@ -100,7 +100,7 @@ async function main() {
         });
 
         await page._client.send('Emulation.clearDeviceMetricsOverride')
-            // Catch URL unreachable error
+        // Catch URL unreachable error
         await page.goto(url, { waitUntil: 'networkidle2' }).catch(e => {
             console.error('Recording URL unreachable!');
             process.exit(2);
@@ -120,15 +120,19 @@ async function main() {
             process.exit(1);
         }
 
-        // Get recording duration
-        var recDuration = await page.evaluate(() => {
-            return (
-                bbbVersionIs23 ?
-                document.getElementById("vjs_video_3_html5_api").duration :
-                document.getElementById("video").duration
+        var recDuration;
 
-            );
-        });
+        // Get recording duration
+        if (bbbVersionIs23) {
+            recDuration = await page.evaluate(() => {
+                return document.getElementById("vjs_video_3_html5_api").duration
+            });
+        } else {
+            recDuration = await page.evaluate(() => {
+                return document.getElementById("video").duration
+            });
+        }
+
         // If duration was set to 0 or is greater than recDuration, use recDuration value
         if (duration == 0 || duration > recDuration) {
             duration = recDuration;

--- a/export.js
+++ b/export.js
@@ -52,7 +52,7 @@ async function main() {
         }
         // Verify if recording URL has the correct format
         var urlRegexV22 = new RegExp('^https?:\\/\\/.*\\/playback\\/presentation\\/2\\.0\\/' + playbackFile + '\\?meetingId=[a-z0-9]{40}-[0-9]{13}');
-        var urlRegexV23 = new RegExp('^https?:\\/\\/.*\\/playback\\/presentation\\/2\\.[0-9]\\/[a-z0-9]{40}-[0-9]{13}');
+        var urlRegexV23 = new RegExp('^https?:\\/\\/.*\\/playback\\/presentation\\/2\\.3\\/[a-z0-9]{40}-[0-9]{13}');
 
         if (!urlRegexV22.test(url) && !urlRegexV23.test(url)) {
             console.warn('Invalid recording URL!');

--- a/export.js
+++ b/export.js
@@ -107,15 +107,24 @@ async function main() {
         })
         await page.setBypassCSP(true)
 
-        // Check if recording exists (search "Recording not found" message)
-        var loadMsg = await page.evaluate(() => {
-            if (document.getElementById("load-msg")) {
-                return document.getElementById("load-msg").textContent;
-            } else {
-                return "";
-            }
-        });
-        if (loadMsg == "Recording not found") {
+        let pageMessage = '';
+
+        // Check if recording exists
+        if (bbbVersionIs23) {
+            pageMessage = await page.evaluate(() => {
+                if (document.getElementById("load-msg")) {
+                    return document.getElementById("load-msg").textContent;
+                }
+            });
+        } else  {
+            pageMessage = await page.evaluate(() => {
+                if (document.getElementsByClassName("error-code")[0]) {
+                    return document.getElementsByClassName("error-code")[0].textContent;
+                }
+            });
+        }
+
+        if (pageMessage === "Recording not found" || pageMessage === "404") {
             console.warn("Recording not found!");
             process.exit(1);
         }

--- a/export.js
+++ b/export.js
@@ -1,5 +1,5 @@
 const puppeteer = require('puppeteer');
-const Xvfb      = require('xvfb');
+const Xvfb = require('xvfb');
 const fs = require('fs');
 const os = require('os');
 const homedir = os.homedir();
@@ -7,76 +7,78 @@ const platform = os.platform();
 const { copyToPath, playbackFile } = require('./env');
 const spawn = require('child_process').spawn;
 
-var xvfb        = new Xvfb({
+var xvfb = new Xvfb({
     silent: true,
     xvfb_args: ["-screen", "0", "1280x800x24", "-ac", "-nolisten", "tcp", "-dpi", "96", "+extension", "RANDR"]
 });
-var width       = 1280;
-var height      = 720;
-var options     = {
-  headless: false,
-  args: [
-    '--enable-usermedia-screen-capturing',
-    '--allow-http-screen-capture',
-    '--auto-select-desktop-capture-source=bbbrecorder',
-    '--load-extension=' + __dirname,
-    '--disable-extensions-except=' + __dirname,
-    '--disable-infobars',
-    '--no-sandbox',
-    '--shm-size=1gb',
-    '--disable-dev-shm-usage',
-    '--start-fullscreen',
-    '--app=https://www.google.com/',
-    `--window-size=${width},${height}`,
-  ],
+var width = 1280;
+var height = 720;
+var options = {
+    headless: false,
+    args: [
+        '--enable-usermedia-screen-capturing',
+        '--allow-http-screen-capture',
+        '--auto-select-desktop-capture-source=bbbrecorder',
+        '--load-extension=' + __dirname,
+        '--disable-extensions-except=' + __dirname,
+        '--disable-infobars',
+        '--no-sandbox',
+        '--shm-size=1gb',
+        '--disable-dev-shm-usage',
+        '--start-fullscreen',
+        '--app=https://www.google.com/',
+        `--window-size=${width},${height}`,
+    ],
 }
 
-if(platform == "linux"){
+if (platform == "linux") {
     options.executablePath = "/usr/bin/google-chrome"
-}else if(platform == "darwin"){
+} else if (platform == "darwin") {
     options.executablePath = "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
 }
 
 async function main() {
     let browser, page;
 
-    try{
-        if(platform == "linux"){
+    try {
+        if (platform == "linux") {
             xvfb.startSync()
         }
 
         var url = process.argv[2];
-        if(!url){
+        if (!url) {
             console.warn('URL undefined!');
             process.exit(1);
         }
         // Verify if recording URL has the correct format
-        var urlRegex = new RegExp('^https?:\\/\\/.*\\/playback\\/presentation\\/2\\.0\\/' + playbackFile + '\\?meetingId=[a-z0-9]{40}-[0-9]{13}');
-        if(!urlRegex.test(url)){
+        var urlRegexV22 = new RegExp('^https?:\\/\\/.*\\/playback\\/presentation\\/2\\.0\\/' + playbackFile + '\\?meetingId=[a-z0-9]{40}-[0-9]{13}');
+        var urlRegexV23 = new RegExp('^https?:\\/\\/.*\\/playback\\/presentation\\/2\\.[0-9]\\/[a-z0-9]{40}-[0-9]{13}');
+
+        if (!urlRegexV22.test(url) && !urlRegexV23.test(url)) {
             console.warn('Invalid recording URL!');
             process.exit(1);
         }
 
         var exportname = process.argv[3];
         // Use meeting ID as export name if it isn't defined or if its value is "MEETING_ID"
-        if(!exportname || exportname == "MEETING_ID"){
+        if (!exportname || exportname == "MEETING_ID") {
             exportname = url.split("=")[1] + '.webm';
         }
 
         var duration = process.argv[4];
         // If duration isn't defined, set it in 0
-        if(!duration){
+        if (!duration) {
             duration = 0;
-        // Check if duration is a natural number
-        }else if(!Number.isInteger(Number(duration)) || duration < 0){
+            // Check if duration is a natural number
+        } else if (!Number.isInteger(Number(duration)) || duration < 0) {
             console.warn('Duration must be a natural number!');
             process.exit(1);
         }
 
         var convert = process.argv[5]
-        if(!convert){
+        if (!convert) {
             convert = false
-        }else if(convert !== "true" && convert !== "false"){
+        } else if (convert !== "true" && convert !== "false") {
             console.warn("Invalid convert value!");
             process.exit(1);
         }
@@ -92,8 +94,8 @@ async function main() {
         });
 
         await page._client.send('Emulation.clearDeviceMetricsOverride')
-        // Catch URL unreachable error
-        await page.goto(url, {waitUntil: 'networkidle2'}).catch(e => {
+            // Catch URL unreachable error
+        await page.goto(url, { waitUntil: 'networkidle2' }).catch(e => {
             console.error('Recording URL unreachable!');
             process.exit(2);
         })
@@ -103,7 +105,7 @@ async function main() {
         var loadMsg = await page.evaluate(() => {
             return document.getElementById("load-msg").textContent;
         });
-        if(loadMsg == "Recording not found"){
+        if (loadMsg == "Recording not found") {
             console.warn("Recording not found!");
             process.exit(1);
         }
@@ -113,7 +115,7 @@ async function main() {
             return document.getElementById("video").duration;
         });
         // If duration was set to 0 or is greater than recDuration, use recDuration value
-        if(duration == 0 || duration > recDuration){
+        if (duration == 0 || duration > recDuration) {
             duration = recDuration;
         }
 
@@ -121,37 +123,37 @@ async function main() {
         await page.$eval('#navbar', element => element.style.display = "none");
         await page.$eval('#copyright', element => element.style.display = "none");
         await page.$eval('.acorn-controls', element => element.style.opacity = "0");
-        await page.click('button[class=acorn-play-button]', {waitUntil: 'domcontentloaded'});
+        await page.click('button[class=acorn-play-button]', { waitUntil: 'domcontentloaded' });
 
         await page.evaluate((x) => {
             console.log("REC_START");
-            window.postMessage({type: 'REC_START'}, '*')
+            window.postMessage({ type: 'REC_START' }, '*')
         })
 
         // Perform any actions that have to be captured in the exported video
         await page.waitFor((duration * 1000))
 
-        await page.evaluate(filename=>{
-            window.postMessage({type: 'SET_EXPORT_PATH', filename: filename}, '*')
-            window.postMessage({type: 'REC_STOP'}, '*')
+        await page.evaluate(filename => {
+            window.postMessage({ type: 'SET_EXPORT_PATH', filename: filename }, '*')
+            window.postMessage({ type: 'REC_STOP' }, '*')
         }, exportname)
 
         // Wait for download of webm to complete
-        await page.waitForSelector('html.downloadComplete', {timeout: 0})
+        await page.waitForSelector('html.downloadComplete', { timeout: 0 })
 
-        if(convert){
+        if (convert) {
             convertAndCopy(exportname)
-        }else{
+        } else {
             copyOnly(exportname)
         }
 
-    }catch(err) {
+    } catch (err) {
         console.log(err)
     } finally {
         page.close && await page.close()
         browser.close && await browser.close()
 
-        if(platform == "linux"){
+        if (platform == "linux") {
             xvfb.stopSync()
         }
     }
@@ -159,7 +161,7 @@ async function main() {
 
 main()
 
-function convertAndCopy(filename){
+function convertAndCopy(filename) {
 
     var copyFromPath = homedir + "/Downloads";
     var onlyfileName = filename.split(".webm")
@@ -167,15 +169,14 @@ function convertAndCopy(filename){
     var copyFrom = copyFromPath + "/" + filename + ""
     var copyTo = copyToPath + "/" + mp4File;
 
-    if(!fs.existsSync(copyToPath)){
+    if (!fs.existsSync(copyToPath)) {
         fs.mkdirSync(copyToPath);
     }
 
     console.log(copyTo);
     console.log(copyFrom);
 
-    const ls = spawn('ffmpeg',
-        [   '-y',
+    const ls = spawn('ffmpeg', ['-y',
             '-i "' + copyFrom + '"',
             '-c:v libx264',
             '-preset veryfast',
@@ -185,8 +186,7 @@ function convertAndCopy(filename){
             '-max_muxing_queue_size 9999',
             '-vf mpdecimate',
             '-vsync vfr "' + copyTo + '"'
-        ],
-        {
+        ], {
             shell: true
         }
 
@@ -202,8 +202,7 @@ function convertAndCopy(filename){
 
     ls.on('close', (code) => {
         console.log(`child process exited with code ${code}`);
-        if(code == 0)
-        {
+        if (code == 0) {
             console.log("Convertion done to here: " + copyTo)
             fs.unlinkSync(copyFrom);
             console.log('successfully deleted ' + copyFrom);
@@ -213,12 +212,12 @@ function convertAndCopy(filename){
 
 }
 
-function copyOnly(filename){
+function copyOnly(filename) {
 
     var copyFrom = homedir + "/Downloads/" + filename;
     var copyTo = copyToPath + "/" + filename;
 
-    if(!fs.existsSync(copyToPath)){
+    if (!fs.existsSync(copyToPath)) {
         fs.mkdirSync(copyToPath);
     }
 


### PR DESCRIPTION
Hi, hope you're doing well.

It seems the playback URL has changed in BBB v2.3. It looks like this:
`https://example.com/playback/presentation/2.3/5f3a37f42fb4e21f91153967bb441b9d6b5478ac-1611595759654`

Which is different from what we had in v2.2. To compare:
`https://example.com/playback/presentation/2.0/playback.html?meetingId=6de6c4496eb598eeb0d55c7c7e4b2a272521e447-1598884103247`
is a v2.2 playback URL.

So I extended/added the RegExp for v2.3. I tested it on one BBB instance <s>and  works</s>, maybe it's better to look at my implementation and if it's okay, then pull it to master. I'm going to test it w/ some other instances and make this PR a draft for now.
After I reviewed it more, I message you here.

Thank you.

P.S. (12:02 PM): The queue in which I put the new recording job has been failed. The problem is w/ CSS selectors, I think.